### PR TITLE
fix [#50] : Suitcase errors on reset app server with empty server

### DIFF
--- a/src/main/java/org/opendatakit/suitcase/model/CloudEndpointInfo.java
+++ b/src/main/java/org/opendatakit/suitcase/model/CloudEndpointInfo.java
@@ -83,6 +83,9 @@ public class CloudEndpointInfo {
     return tableIdSchemaETag.containsKey(tableId);
   }
 
+  public void resetTableIdSchemaETag() {
+  	tableIdSchemaETag.clear();
+  }
   /**
    * Attempts to fix some problems with serverUrl
    *

--- a/src/main/java/org/opendatakit/suitcase/net/SyncWrapper.java
+++ b/src/main/java/org/opendatakit/suitcase/net/SyncWrapper.java
@@ -76,6 +76,8 @@ public class SyncWrapper {
   }
 
   public Set<String> updateTableList() throws IOException, JSONException {
+  	cloudEndpointInfo.resetTableIdSchemaETag();
+  	
     JSONArray tables =
         sc.getTables(cloudEndpointInfo.getServerUrl(), cloudEndpointInfo.getAppId()).getJSONArray(TABLES_JSON);
 


### PR DESCRIPTION
addresses [odk-x/tool-suite-X#50](https://github.com/odk-x/tool-suite-X/issues/50)

Problem: Resetting the server twice produced error.
Cause: Redundant entry in tables map after the first reset.
Fix: Removing the redundant entry by, clearing the table map before adding the queried table entries to it in the `updateTableList()` method

![resetfix](https://user-images.githubusercontent.com/35284932/111676104-d6088100-8843-11eb-8d97-35c7c58e90f6.gif)
