### PR TITLE
Added error message for scan formatting error

### DIFF
--- a/src/main/java/org/opendatakit/suitcase/model/CsvConfig.java
+++ b/src/main/java/org/opendatakit/suitcase/model/CsvConfig.java
@@ -27,6 +27,10 @@ public class CsvConfig {
     return extraMetadata;
   }
 
+  public void setScanFormatting(boolean scanFormatting) {
+    this.scanFormatting = scanFormatting;
+  }
+
   @Override
   public String toString() {
     return "CsvConfig{" +

--- a/src/main/java/org/opendatakit/suitcase/model/ODKCsv.java
+++ b/src/main/java/org/opendatakit/suitcase/model/ODKCsv.java
@@ -2,6 +2,7 @@ package org.opendatakit.suitcase.model;
 
 import org.opendatakit.suitcase.net.AttachmentManager;
 import org.opendatakit.suitcase.net.SyncWrapper;
+import org.opendatakit.suitcase.ui.DialogUtils;
 import org.opendatakit.sync.data.ColumnDefinition;
 import org.apache.wink.json4j.JSONArray;
 import org.apache.wink.json4j.JSONException;
@@ -482,8 +483,16 @@ public class ODKCsv implements Iterable<String[]> {
       this.attMngr.getListOfRowAttachments(rowId);
 
       if (config.isScanFormatting()) {
-        this.attMngr.downloadAttachments(rowId, true);
-        scanRaw = new ScanJson(this.attMngr.getScanRawJsonStream(rowId));
+          try {
+              this.attMngr.downloadAttachments(rowId, true);
+              scanRaw = new ScanJson(this.attMngr.getScanRawJsonStream(rowId));
+          }
+          catch (JSONException e)
+          {
+              e.printStackTrace();
+              DialogUtils.showError("Scan formatting is not possible for the selected table",true);
+              config.setScanFormatting(false);
+          }
       }
     }
 


### PR DESCRIPTION
Scan json object is only created if scan formatting is checked as true .Try catch is added to catch JSONException thrown by ScanJson . After error occurs scan formatting is set to false for the remaining rows and error message is displayed .
should fix https://github.com/odk-x/tool-suite-X/issues/220