### PR TITLE
Empty directory selection disabled

### DIFF
--- a/src/main/java/org/opendatakit/suitcase/ui/MessageString.java
+++ b/src/main/java/org/opendatakit/suitcase/ui/MessageString.java
@@ -39,7 +39,7 @@ public class MessageString {
   public static final String VERSION_EMPTY = "Version" + CANNOT_EMPTY_SUFFIX;
   public static final String DATA_PATH_EMPTY = "Data path" + CANNOT_EMPTY_SUFFIX;
   public static final String SAVE_PATH_EMPTY = "Save path" + CANNOT_EMPTY_SUFFIX;
-
+  public static final String DIRECTORY_EMPTY = "Directory" + CANNOT_EMPTY_SUFFIX;
   // Prompts
   public static final String OVERWRITE_DATA = "Data from a previous session detected. Delete existing data and download data from the Cloud Endpoint?";
   public static final String OVERWRITE_CSV = "This CSV has already been downloaded. Delete existing CSV and download data from the Cloud Endpoint?";

--- a/src/main/java/org/opendatakit/suitcase/ui/PathChooserPanel.java
+++ b/src/main/java/org/opendatakit/suitcase/ui/PathChooserPanel.java
@@ -45,6 +45,11 @@ public class PathChooserPanel extends JPanel{
 
         int result = chooser.showSaveDialog(null);
         if (result == JFileChooser.APPROVE_OPTION) {
+        	File file = chooser.getSelectedFile();
+          if(isDirectoryEmpty(file)) {
+               DialogUtils.showError(MessageString.DIRECTORY_EMPTY, true);
+            }
+          else
           pathText.setText(chooser.getSelectedFile().toString());
         }
       }
@@ -62,4 +67,8 @@ public class PathChooserPanel extends JPanel{
   private static String sanitizePath(String path) {
     return path.replaceAll("^\\s+", "");
   }
+  public static boolean isDirectoryEmpty(File directory) {  
+	    String[] files = directory.list();
+	    return files.length == 0;  
+	}
 }


### PR DESCRIPTION
issue fixes: https://github.com/odk-x/tool-suite-X/issues/262

Now, the save option won't select empty directory and will give a error message whenever an empty directory is selected.

preview of the change:

https://user-images.githubusercontent.com/57134307/115506019-fd65ca00-a297-11eb-908a-62f0d438eb08.mp4

