### PR TITLE
Updated README.md to address Maven 3.9.0 bug on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ The developer [wiki](https://github.com/odk-x/tool-suite-X/wiki) (including rele
 ## Setting up Your Environment
 
 1. Install Maven and Ant onto your system.
-1. Run `ant` in the dependencies folder. 
-1. From the root directory (with the pom.xml), run: *mvn clean package*
+(We recommend using [Maven 3.8.6](https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/) if you are on Windows, and downloading the binary directly. Maven 3.9.0 currently has some issues that would cause the build to fail)
+
+2. Run `ant` in the dependencies folder. 
+3. From the root directory (with the pom.xml), run: *mvn clean package*
 
 A new folder, target, will be created with the resulting jar file. 
 


### PR DESCRIPTION
Updated README.md to address Maven 3.9.0 bug on Windows causing the build to fail and recommended using Maven 3.8.6